### PR TITLE
Add NovaSpatiePermissionsServiceProvider to providers autoload.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Itsmejoshua\\Novaspatiepermissions\\ToolServiceProvider"
+                "Itsmejoshua\\Novaspatiepermissions\\ToolServiceProvider",
+                "Itsmejoshua\\Novaspatiepermissions\\NovaSpatiePermissionsServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
Hello.

Thank you for your work!

I noticed we have to add manually this file `Itsmejoshua\\Novaspatiepermissions\\NovaSpatiePermissionsServiceProvider`, even if we have provider discovery on. 

The packages has 2 ServiceProviders, and it's referencing only 1 in the discovery process (composer extra).

This way, we will not need to touch `config/app.php` if with auto discovery.

Let me know what. you think.

Thanks