### PR TITLE
Fixes Nova password reset errror

### DIFF
--- a/src/PermissionsBasedAuthTrait.php
+++ b/src/PermissionsBasedAuthTrait.php
@@ -180,7 +180,7 @@ trait PermissionsBasedAuthTrait
 	public static function hasPermissionsTo(Request $request, $ability)
 	{
 	
-		if($request->GetRequestUri()==config('nova.path')."/login"){
+		if($request->GetRequestUri()==config('nova.path')."/login" || $request->GetRequestUri()==config('nova.path')."/password/reset"){
 			return true;
 		}
 		


### PR DESCRIPTION
Currently nova reset password throws an error.
Adding the /password/reset route in PermissionsBasedAuthTrait.php will allow this route and prevent the error